### PR TITLE
Give the example hook a configurable challenge path

### DIFF
--- a/uacme.sh
+++ b/uacme.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CHALLENGE_PATH=/var/www/.well-known/acme-challenge
+CHALLENGE_PATH="${UACME_CHALLENGE_PATH:-'/var/www/.well-known/acme-challenge'}"
 ARGS=5
 E_BADARGS=85
 


### PR DESCRIPTION
Because the challenge-path for `uacme` is determined by the hook, it would be pleasant if the example/default hook provided by upstream allowed for easy configuration of the challenge path.

For my use case, it would mean that, instead of needing to vendor this hook (which generally appears to be all I could need) into my own repository just so I can change the challenge path, I can instead grab the upstream copy and use it verbatim (getting updates if necessary without needing to merge my changes in the future) and just export an environment variable (which, for simplicity, I proposed be named `UACME_CHALLENGE_PATH`).