### PR TITLE
Parse (non-folded) headers correctly

### DIFF
--- a/uacme.c
+++ b/uacme.c
@@ -72,7 +72,7 @@ typedef struct acme
 char *find_header(const char *headers, const char *name)
 {
     char *regex = NULL;
-    if (asprintf(&regex, "^%s: (.*)\r\n", name) < 0)
+    if (asprintf(&regex, "^%s:[ \t]*(.*)\r\n", name) < 0)
     {
         warnx("find_header: asprintf failed");
         return NULL;

--- a/uacme.c
+++ b/uacme.c
@@ -79,7 +79,7 @@ char *find_header(const char *headers, const char *name)
     }
     char *ret = NULL;
     regex_t reg;
-    if (regcomp(&reg, regex, REG_EXTENDED | REG_NEWLINE))
+    if (regcomp(&reg, regex, REG_EXTENDED | REG_ICASE | REG_NEWLINE))
     {
         warnx("find_header: regcomp failed");
     }


### PR DESCRIPTION
HTTP header names are case-insensitive ([RFC 7230 §3.2]) and should be matched as such. Also, the whitespace between the colon and the header value is optional and can include any number of spaces or horizontal tabulations.

At least on my machine, the Let’s Encrypt ACME directory is retreived over HTTP/2 and the Content-Type header is named in all lowercase, leading to uacme without this fix failing completely.

Note that, in principle, a compliant HTTP user agent MUST also handle obsolete line folding ([RFC 7230 §3.2.4]). This PR does not address line folding, as I did not want to make the regex significantly more complex without anything to test it on.

[RFC 7230 §3.2]: https://tools.ietf.org/html/rfc7230#section-3.2
[RFC 7230 §3.2.4]: https://tools.ietf.org/html/rfc7230#section-3.2.4