### PR TITLE
Fix uacme.sh

### DIFF
--- a/uacme.sh
+++ b/uacme.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CHALLENGE_PATH="${UACME_CHALLENGE_PATH:-'/var/www/.well-known/acme-challenge'}"
+CHALLENGE_PATH="${UACME_CHALLENGE_PATH:-/var/www/.well-known/acme-challenge}"
 ARGS=5
 E_BADARGS=85
 

--- a/uacme.sh
+++ b/uacme.sh
@@ -22,7 +22,7 @@ E_BADARGS=85
 
 if test $# -ne "$ARGS"
 then
-    echo "Usage: `basename $0` method type ident token auth" 1>&2
+    echo "Usage: $(basename "$0") method type ident token auth" 1>&2
     exit $E_BADARGS
 fi
 
@@ -36,7 +36,7 @@ case "$METHOD" in
     "begin")
         case "$TYPE" in
             http-01)
-                echo -n "${AUTH}" > ${CHALLENGE_PATH}/${TOKEN}
+                echo -n "${AUTH}" > "${CHALLENGE_PATH}/${TOKEN}"
                 exit $?
                 ;;
             *)
@@ -48,7 +48,7 @@ case "$METHOD" in
     "done"|"failed")
         case "$TYPE" in
             http-01)
-                rm ${CHALLENGE_PATH}/${TOKEN}
+                rm "${CHALLENGE_PATH}/${TOKEN}"
                 exit $?
                 ;;
             *)


### PR DESCRIPTION
Single quotes don't work inside parameter expansion as in other places. They are not stripped during expansion but become part of the value. Thus this will result in:

    CHALLENGE_PATH="'/var/www/.well-known/acme-challenge'"

Since the default path doesn't contain any spaces, it's not needed to quote it at all.

This bug was introduced in 8f8b9fa.