### PR TITLE
certonly functionality- CSR signing only.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ $(top_srcdir)/.version:
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball-version
 
-dist_pkgdata_SCRIPTS = uacme.sh
+dist_pkgdata_SCRIPTS = uacme.sh dns-01.sh
 if ENABLE_UALPN
 dist_pkgdata_SCRIPTS += ualpn.sh
 endif
@@ -104,9 +104,10 @@ valgrind: uacme
 	    --num-callers=20 --track-fds=yes --log-file=valgrind.log \
 	    $(builddir)/uacme $(VALGRIND_UACME_ARGS)
 
-EXTRA_DIST = GNUmakefile build-aux/git-version-gen uacme.sh uacme.1.txt \
-	     uacme.1 docs/uacme.html ualpn.1.txt ualpn.1 docs/ualpn.html \
-	     libev/ev_epoll.c libev/ev_iouring.c libev/ev_kqueue.c \
-	     libev/ev_linuxaio.c libev/ev_poll.c libev/ev_port.c \
-	     libev/ev_select.c libev/ev_vars.h libev/ev_wrap.h
+EXTRA_DIST = GNUmakefile build-aux/git-version-gen uacme.sh dns-01.sh \
+	     uacme.1.txt uacme.1 docs/uacme.html ualpn.1.txt ualpn.1 \
+	     docs/ualpn.html libev/ev_epoll.c libev/ev_iouring.c \
+	     libev/ev_kqueue.c libev/ev_linuxaio.c libev/ev_poll.c \
+	     libev/ev_port.c libev/ev_select.c libev/ev_vars.h \
+	     libev/ev_wrap.h
 CLEANFILES = valgrind.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,8 +39,8 @@ endif
 endif
 
 uacme_SOURCES = uacme.c base64.c base64.h crypto.c crypto.h \
-		curlwrap.c curlwrap.h json.c json.h jsmn.h \
-		msg.c msg.h
+		curlwrap.c curlwrap.h idents.c idents.h json.c \
+		json.h jsmn.h msg.c msg.h
 uacme_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\"" \
 		 -DSYSCONFDIR="\"${sysconfdir}\"" \
 		 $(CURL_CPPFLAGS)

--- a/Makefile.in
+++ b/Makefile.in
@@ -172,7 +172,7 @@ ualpn_OBJECTS = $(am_ualpn_OBJECTS)
 @ENABLE_UALPN_TRUE@	$(am__append_4)
 ualpn_LINK = $(CCLD) $(ualpn_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) \
 	$(LDFLAGS) -o $@
-am__dist_pkgdata_SCRIPTS_DIST = uacme.sh ualpn.sh
+am__dist_pkgdata_SCRIPTS_DIST = uacme.sh dns-01.sh ualpn.sh
 am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
 am__vpath_adj = case $$p in \
     $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
@@ -422,14 +422,15 @@ uacme_CFLAGS = $(CURL_CFLAGS) $(WCFLAGS)
 uacme_LDFLAGS = $(CURL_LDFLAGS)
 uacme_LDADD = $(CURL_LDADD)
 BUILT_SOURCES = $(top_srcdir)/.version
-dist_pkgdata_SCRIPTS = uacme.sh $(am__append_6)
+dist_pkgdata_SCRIPTS = uacme.sh dns-01.sh $(am__append_6)
 @ENABLE_DOCS_TRUE@dist_man1_MANS = uacme.1 $(am__append_7)
 @ENABLE_DOCS_TRUE@dist_html_DATA = docs/uacme.html $(am__append_8)
-EXTRA_DIST = GNUmakefile build-aux/git-version-gen uacme.sh uacme.1.txt \
-	     uacme.1 docs/uacme.html ualpn.1.txt ualpn.1 docs/ualpn.html \
-	     libev/ev_epoll.c libev/ev_iouring.c libev/ev_kqueue.c \
-	     libev/ev_linuxaio.c libev/ev_poll.c libev/ev_port.c \
-	     libev/ev_select.c libev/ev_vars.h libev/ev_wrap.h
+EXTRA_DIST = GNUmakefile build-aux/git-version-gen uacme.sh dns-01.sh \
+	     uacme.1.txt uacme.1 docs/uacme.html ualpn.1.txt ualpn.1 \
+	     docs/ualpn.html libev/ev_epoll.c libev/ev_iouring.c \
+	     libev/ev_kqueue.c libev/ev_linuxaio.c libev/ev_poll.c \
+	     libev/ev_port.c libev/ev_select.c libev/ev_vars.h \
+	     libev/ev_wrap.h
 
 CLEANFILES = valgrind.log
 all: $(BUILT_SOURCES) config.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -149,12 +149,13 @@ am__installdirs = "$(DESTDIR)$(bindir)" "$(DESTDIR)$(pkgdatadir)" \
 	"$(DESTDIR)$(man1dir)" "$(DESTDIR)$(htmldir)"
 PROGRAMS = $(bin_PROGRAMS)
 am__uacme_SOURCES_DIST = uacme.c base64.c base64.h crypto.c crypto.h \
-	curlwrap.c curlwrap.h json.c json.h jsmn.h msg.c msg.h \
-	read-file.c read-file.h
+	curlwrap.c curlwrap.h idents.c idents.h json.c json.h jsmn.h \
+	msg.c msg.h read-file.c read-file.h
 @ENABLE_READFILE_TRUE@am__objects_1 = uacme-read-file.$(OBJEXT)
 am_uacme_OBJECTS = uacme-uacme.$(OBJEXT) uacme-base64.$(OBJEXT) \
 	uacme-crypto.$(OBJEXT) uacme-curlwrap.$(OBJEXT) \
-	uacme-json.$(OBJEXT) uacme-msg.$(OBJEXT) $(am__objects_1)
+	uacme-idents.$(OBJEXT) uacme-json.$(OBJEXT) \
+	uacme-msg.$(OBJEXT) $(am__objects_1)
 uacme_OBJECTS = $(am_uacme_OBJECTS)
 am__DEPENDENCIES_1 =
 uacme_DEPENDENCIES = $(am__DEPENDENCIES_1)
@@ -391,7 +392,6 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
-runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -412,7 +412,8 @@ ARFLAGS = cr
 @ENABLE_LIBEV_TRUE@@ENABLE_UALPN_TRUE@noinst_LIBRARIES = libev.a
 @ENABLE_LIBEV_TRUE@@ENABLE_UALPN_TRUE@libev_a_SOURCES = libev/ev.c
 uacme_SOURCES = uacme.c base64.c base64.h crypto.c crypto.h curlwrap.c \
-	curlwrap.h json.c json.h jsmn.h msg.c msg.h $(am__append_5)
+	curlwrap.h idents.c idents.h json.c json.h jsmn.h msg.c msg.h \
+	$(am__append_5)
 uacme_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\"" \
 		 -DSYSCONFDIR="\"${sysconfdir}\"" \
 		 $(CURL_CPPFLAGS)
@@ -596,6 +597,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-base64.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-crypto.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-curlwrap.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-idents.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-json.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-msg.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/uacme-read-file.Po@am__quote@
@@ -676,6 +678,20 @@ uacme-curlwrap.obj: curlwrap.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='curlwrap.c' object='uacme-curlwrap.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -c -o uacme-curlwrap.obj `if test -f 'curlwrap.c'; then $(CYGPATH_W) 'curlwrap.c'; else $(CYGPATH_W) '$(srcdir)/curlwrap.c'; fi`
+
+uacme-idents.o: idents.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -MT uacme-idents.o -MD -MP -MF $(DEPDIR)/uacme-idents.Tpo -c -o uacme-idents.o `test -f 'idents.c' || echo '$(srcdir)/'`idents.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/uacme-idents.Tpo $(DEPDIR)/uacme-idents.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='idents.c' object='uacme-idents.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -c -o uacme-idents.o `test -f 'idents.c' || echo '$(srcdir)/'`idents.c
+
+uacme-idents.obj: idents.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -MT uacme-idents.obj -MD -MP -MF $(DEPDIR)/uacme-idents.Tpo -c -o uacme-idents.obj `if test -f 'idents.c'; then $(CYGPATH_W) 'idents.c'; else $(CYGPATH_W) '$(srcdir)/idents.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/uacme-idents.Tpo $(DEPDIR)/uacme-idents.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='idents.c' object='uacme-idents.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -c -o uacme-idents.obj `if test -f 'idents.c'; then $(CYGPATH_W) 'idents.c'; else $(CYGPATH_W) '$(srcdir)/idents.c'; fi`
 
 uacme-json.o: json.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(uacme_CPPFLAGS) $(CPPFLAGS) $(uacme_CFLAGS) $(CFLAGS) -MT uacme-json.o -MD -MP -MF $(DEPDIR)/uacme-json.Tpo -c -o uacme-json.o `test -f 'json.c' || echo '$(srcdir)/'`json.c

--- a/crypto.c
+++ b/crypto.c
@@ -35,6 +35,7 @@
 #include "base64.h"
 #include "crypto.h"
 #include "curlwrap.h"
+#include "idents.h"
 #include "msg.h"
 #if !defined(USE_OPENSSL)
 #include "read-file.h"
@@ -3127,3 +3128,38 @@ out:
     free(certdata);
     return ret;
 }
+
+static char* base64encode(unsigned char* binary, size_t size)
+{
+    char* base64 = NULL;
+    int r;
+
+    r = base64_ENCODED_LEN(size, base64_VARIANT_URLSAFE_NO_PADDING);
+    if (!(base64 = calloc(r, sizeof(unsigned char)))) {
+        warn("base64encode: calloc failed");
+        goto out;
+    }
+
+    if (!bin2base64(base64, r, binary, size,
+                    base64_VARIANT_URLSAFE_NO_PADDING)) {
+        free(base64);
+        goto out;
+    }
+
+out:
+    return base64;
+}
+
+#if defined(USE_OPENSSL)
+int csr_read(const char* csr_file, char** base64, char*** ident)
+{
+}
+#elif defined(USE_GNUTLS)
+int csr_read(const char* csr_file, char** base64, char*** ident)
+{
+}
+#elif defined(USE_MBEDTLS)
+int csr_read(const char* csr_file, char** base64, char*** ident)
+{
+}
+#endif

--- a/crypto.h
+++ b/crypto.h
@@ -77,6 +77,7 @@ keytype_t key_type(privkey_t);
 privkey_t key_load(keytype_t, int bits, const char *, ...);
 bool is_ip(const char *, unsigned char *, size_t *);
 char *csr_gen(const char * const *, bool, privkey_t);
+int csr_read(const char*, char**, char***);
 char *cert_der_base64url(const char *);
 bool cert_valid(const char *, const char * const *, int, bool);
 

--- a/dns-01.sh
+++ b/dns-01.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+# Copyright (C) 2020 Michel Stam <michel@reverze.net>
+#
+# This file is part of uacme.
+#
+# uacme is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# uacme is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Commands
+DIG=dig
+RNDC=rndc
+NSUPDATE=nsupdate
+
+# Files
+# RNDC_KEY
+#   if you wish to specify an RDC key for TSIG transactions, do so
+#   here. If you do, also make sure /etc/named.conf specifies the
+#   key "KEYNAME"; in the zone that must be updated (and disallow
+#   all others for safety) 
+RNDC_KEY=
+
+# Arguments
+METHOD=$1
+TYPE=$2
+IDENT=$3
+TOKEN=$4
+AUTH=$5
+
+ns_getdomain()
+{
+    local fqhn="$1"
+    local idx
+    local ret=''
+    OLDIFS="$IFS"
+    IFS=.
+ 
+    set -- $fqhn
+    idx=$#
+
+    if [ $idx -gt 1 ]; then
+        eval ret="\$$idx"
+        idx=$((idx-1))
+        eval ret="\$$idx.\$ret"
+    fi
+
+    IFS="$OLDIFS"
+    echo $ret
+}
+
+ns_gethostname()
+{
+    local fqhn="$1"
+    local ret=''
+    local idx=1
+ 
+    OLDIFS="${IFS}"
+    IFS='.'
+    set -- ${fqhn}
+    IFS="${OLDIFS}"
+
+    if [ $# -ge 2 ]; then
+        max=$(( $# - 2 ))
+    else
+        max=1
+    fi
+
+    while [ $idx -le $max ]; do
+        eval ret="$ret.\$$idx"
+        idx=$((idx + 1))
+    done
+
+    echo ${ret:1}
+}
+
+
+ns_getprimary()
+{
+    local domain=$1
+
+    [ -n "$domain" ] || return
+    set -- $($DIG ${RNDC_KEY:+-k ${RNDC_KEY}} +short "$domain" SOA 2>/dev/null)
+
+    echo $1
+}
+    
+ns_getall()
+{
+    local domain=$1
+
+    [ -n "$domain" ] || return 1
+
+    $DIG ${RNDC_KEY:+-k ${RNDC_KEY}} +short "$domain" NS 2>/dev/null
+}
+
+ns_ispresent()
+{
+    local fqhn="$1"
+    local expect="$2"
+    local domain=$(ns_getdomain "$fqhn")
+    local nameservers=$(ns_getall "$domain")
+    local res
+    local ret
+
+    for NS in $nameservers; do
+        res=$($DIG ${RNDC_KEY:+-k ${RNDC_KEY}} +short "@$NS" "$fqhn" TXT 2>/dev/null)
+        res="${res//\"/}"
+        [ "$res" == "$expect" ] || return 1
+    done
+
+    return 0
+}
+
+ns_doupdate()
+{
+    local fqhn="$1"
+    local challenge="$2"
+    local ttl=600
+    local domain=$(ns_getdomain "$fqhn")
+    local nameserver=$(ns_getprimary "$domain")
+    local action=
+
+    [ -n "$nameserver" ] || return
+
+    if [ -n "${challenge}" ]; then
+            action="update add ${fqhn}. ${ttl} IN TXT ${challenge}"
+    else
+            action="update del ${fqhn}."
+    fi
+
+    $NSUPDATE ${RNDC_KEY:+-k ${RNDC_KEY}} -v <<-EOF
+            server ${nameserver}
+            ${action}
+            send
+EOF
+
+    return $?
+}
+
+ns_update()
+{
+    local fqhn="$1"
+    local challenge="$2"
+    local count=0
+    local res
+
+    res=1
+    while [ $res -ne 0 ]; do
+        if [ $count -eq 0 ]; then
+            ns_doupdate "$fqhn" "$challenge"
+            res=$?
+            [ $res -eq 0 ] || break
+        else
+            sleep 1
+        fi
+
+        count=$(((count + 1) % 5))
+        ns_ispresent "$fqhn" "$challenge"
+        res=$?
+    done
+
+    return $?
+}
+
+ARGS=5
+E_BADARGS=85
+
+if [ $# -ne "$ARGS" ]; then
+    echo "Usage: $(basename "$0") method type ident token auth" 1>&2
+    exit $E_BADARGS
+fi
+
+case "$METHOD" in
+    "begin")
+        case "$TYPE" in
+            dns-01)
+                ns_update "_acme-challenge.$IDENT" "$AUTH"
+                exit $?
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+
+    "done"|"failed")
+        case "$TYPE" in
+            dns-01)
+                ns_update "_acme-challenge.$IDENT"
+                exit $?
+                ;;
+            *)
+                exit 1
+                ;;
+        esac
+        ;;
+
+    *)
+        echo "$0: invalid method" 1>&2
+        exit 1
+esac

--- a/docs/uacme.html
+++ b/docs/uacme.html
@@ -752,7 +752,8 @@ UACME(1) Manual Page
     [<strong>-o</strong>|<strong>--no-ocsp</strong>] [<strong>-s</strong>|<strong>--staging</strong>] [<strong>-t</strong>|<strong>--type</strong> <strong>RSA</strong>|<strong>EC</strong>]
     [<strong>-v</strong>|<strong>--verbose</strong> &#8230;] [<strong>-V</strong>|<strong>--version</strong>] [<strong>-y</strong>|<strong>--yes</strong>] [<strong>-?</strong>|<strong>--help</strong>]
     <strong>new</strong> [<em>EMAIL</em>] | <strong>update</strong> [<em>EMAIL</em>] | <strong>deactivate</strong> | <strong>newkey</strong> |
-    <strong>issue</strong> <em>IDENTIFIER</em> [<em>ALTNAME</em> &#8230;]] | <strong>revoke</strong> <em>CERTFILE</em></p></div>
+    <strong>issue</strong> <em>IDENTIFIER</em> [<em>ALTNAME</em> &#8230;]] | <strong>revoke</strong> <em>CERTFILE</em> |
+    <strong>signonly</strong> <em>CSR</em></p></div>
 </div>
 </div>
 <div class="sect1">
@@ -1114,6 +1115,15 @@ The key authorization (for <strong>dns-01</strong> and <strong>tls-alpn-01</stro
     <em>CONFDIR/test.com/cert.pem</em>.
     IP address IDENTIFIERs and ALTNAMEs are also supported according to
     <a href="https://tools.ietf.org/html/rfc8738#section-3">https://tools.ietf.org/html/rfc8738#section-3</a>
+</p>
+</dd>
+<dt class="hdlist1">
+<strong>uacme</strong> [<em>OPTIONS</em> &#8230;] <strong>signonly</strong> <em>CSR</em>
+</dt>
+<dd>
+<p>
+    Issue a certificate for the certificate signing request stored in
+    <em>CSR</em>. If successful the certificate will be stored in <em>CSR.cert.pem</em>.
 </p>
 </dd>
 <dt class="hdlist1">

--- a/idents.c
+++ b/idents.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 Michel Stam <michel@reverze.net>
+ *
+ * This file is part of uacme.
+ *
+ * uacme is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * uacme is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "idents.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+void idents_init(struct idents* id)
+{
+    memset((void*)id, 0, sizeof(struct idents));
+    id->len = sizeof (char*);
+}
+
+int idents_alloc(struct idents* id)
+{
+    id->base = (char**) malloc(id->len);
+    if (id->base) {
+        id->end = ((char*) id->base) + id->len;
+        id->strings = (char*) &(id->base[id->args+1]);
+        id->cur_ptr = id->base;
+        id->cur_str = id->strings;
+        id->base[id->args] = NULL;
+    }
+
+    return (id->base == NULL);
+}
+
+int idents_commit(struct idents* id, size_t len)
+{
+    int res = 1;
+    char* tmp;
+
+    if (id->cur_ptr == &(id->base[id->args]))
+        goto end;
+
+    tmp = id->cur_str;
+
+    id->cur_str += len;
+    if (idents_left(id) <= 0) {
+       id->cur_str = tmp;
+       goto end;
+    }
+    *(id->cur_ptr) = tmp;
+    id->cur_ptr ++;
+    *(id->cur_str) = '\0';
+    id->cur_str ++;
+
+    res = 0;
+
+end:
+    return res;
+}

--- a/idents.h
+++ b/idents.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Michel Stam <michel@reverze.net>
+ *
+ * This file is part of uacme.
+ *
+ * uacme is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * uacme is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __IDENTS_H__
+#define __IDENTS_H__
+
+#include <stdint.h>
+#include <unistd.h>
+
+struct idents {
+    char** base;
+    size_t len;
+    int args;
+    char* end;
+
+    char* strings;
+    char**cur_ptr;
+    char* cur_str;
+};
+
+
+#define idents_addarg(i, l) (i)->len += l + sizeof(char*) + 1, (i)->args ++
+#define idents_get(i) (i)->base
+#define idents_here(i) (i)->cur_str
+#define idents_left(i) ((i)->end - (i)->cur_str)
+
+int idents_alloc(struct idents*);
+int idents_commit(struct idents*, size_t);
+void idents_init(struct idents*);
+
+#endif

--- a/uacme.1
+++ b/uacme.1
@@ -31,7 +31,7 @@
 uacme \- ACMEv2 client written in plain C code with minimal dependencies
 .SH "SYNOPSIS"
 .sp
-\fBuacme\fR [\fB\-a\fR|\fB\-\-acme\-url\fR \fIURL\fR] [\fB\-b\fR|\fB\-\-bits\fR \fIBITS\fR] [\fB\-c\fR|\fB\-\-confdir\fR \fIDIR\fR] [\fB\-d\fR|\fB\-\-days\fR \fIDAYS\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-hook\fR \fIPROGRAM\fR] [\fB\-m\fR|\fB\-\-must\-staple\fR] [\fB\-n\fR|\fB\-\-never\-create\fR] [\fB\-o\fR|\fB\-\-no\-ocsp\fR] [\fB\-s\fR|\fB\-\-staging\fR] [\fB\-t\fR|\fB\-\-type\fR \fBRSA\fR|\fBEC\fR] [\fB\-v\fR|\fB\-\-verbose\fR \&...] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-y\fR|\fB\-\-yes\fR] [\fB\-?\fR|\fB\-\-help\fR] \fBnew\fR [\fIEMAIL\fR] | \fBupdate\fR [\fIEMAIL\fR] | \fBdeactivate\fR | \fBnewkey\fR | \fBissue\fR \fIIDENTIFIER\fR [\fIALTNAME\fR \&...]] | \fBrevoke\fR \fICERTFILE\fR
+\fBuacme\fR [\fB\-a\fR|\fB\-\-acme\-url\fR \fIURL\fR] [\fB\-b\fR|\fB\-\-bits\fR \fIBITS\fR] [\fB\-c\fR|\fB\-\-confdir\fR \fIDIR\fR] [\fB\-d\fR|\fB\-\-days\fR \fIDAYS\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-hook\fR \fIPROGRAM\fR] [\fB\-m\fR|\fB\-\-must\-staple\fR] [\fB\-n\fR|\fB\-\-never\-create\fR] [\fB\-o\fR|\fB\-\-no\-ocsp\fR] [\fB\-s\fR|\fB\-\-staging\fR] [\fB\-t\fR|\fB\-\-type\fR \fBRSA\fR|\fBEC\fR] [\fB\-v\fR|\fB\-\-verbose\fR \&...] [\fB\-V\fR|\fB\-\-version\fR] [\fB\-y\fR|\fB\-\-yes\fR] [\fB\-?\fR|\fB\-\-help\fR] \fBnew\fR [\fIEMAIL\fR] | \fBupdate\fR [\fIEMAIL\fR] | \fBdeactivate\fR | \fBnewkey\fR | \fBissue\fR \fIIDENTIFIER\fR [\fIALTNAME\fR \&...]] | \fBrevoke\fR \fICERTFILE\fR | \fBsignonly\fR \fICSR\fR
 .SH "DESCRIPTION"
 .sp
 \fBuacme\fR is a client for the ACMEv2 protocol described in RFC8555, written in plain C code with minimal dependencies (libcurl and one of GnuTLS, OpenSSL or mbedTLS)\&. The ACMEv2 protocol allows a Certificate Authority (https://letsencrypt\&.org is a popular one) and an applicant to automate the process of verification and certificate issuance\&. The protocol also provides facilities for other certificate management functions, such as certificate revocation\&. For more information see https://tools\&.ietf\&.org/html/rfc8555
@@ -312,6 +312,13 @@ is specified\&. Wildcard IDENTIFIERs or ALTNAMEs are dealt with correctly, as lo
 is saved to
 \fICONFDIR/test\&.com/cert\&.pem\fR\&. IP address IDENTIFIERs and ALTNAMEs are also supported according to
 https://tools\&.ietf\&.org/html/rfc8738#section\-3
+.RE
+.PP
+\fBuacme\fR [\fIOPTIONS\fR \&...] \fBsignonly\fR \fICSR\fR
+.RS 4
+Issue a certificate for the certificate signing request stored in
+\fICSR\fR\&. If successful the certificate will be stored in
+\fICSR\&.cert\&.pem\fR\&.
 .RE
 .PP
 \fBuacme\fR [\fIOPTIONS\fR \&...] \fBrevoke\fR \fICERTFILE\fR

--- a/uacme.1.txt
+++ b/uacme.1.txt
@@ -19,7 +19,8 @@ SYNOPSIS
     [*-o*|*--no-ocsp*] [*-s*|*--staging*] [*-t*|*--type* *RSA*|*EC*]
     [*-v*|*--verbose* ...] [*-V*|*--version*] [*-y*|*--yes*] [*-?*|*--help*]
     *new* ['EMAIL'] | *update* ['EMAIL'] | *deactivate* | *newkey* |
-    *issue* 'IDENTIFIER' ['ALTNAME' ...]] | *revoke* 'CERTFILE'
+    *issue* 'IDENTIFIER' ['ALTNAME' ...]] | *revoke* 'CERTFILE' |
+    *signonly* 'CSR'
 
 
 DESCRIPTION
@@ -178,6 +179,10 @@ USAGE
     'CONFDIR/test.com/cert.pem'.
     IP address IDENTIFIERs and ALTNAMEs are also supported according to
     <https://tools.ietf.org/html/rfc8738#section-3>
+
+*uacme* ['OPTIONS' ...] *signonly* 'CSR'::
+    Issue a certificate for the certificate signing request stored in
+    'CSR'. If successful the certificate will be stored in 'CSR.cert.pem'.
 
 *uacme* ['OPTIONS' ...] *revoke* 'CERTFILE'::
     Revoke the certificate stored in 'CERTFILE'. Only certificates


### PR DESCRIPTION
Hi,

A couple of patches I wrote that add certonly functionality, basically to sign a CSR. Used sometimes for routers, etc.

I have tested the GNUTLS and that works. OpenSSL and MBEDTLS I tested by verifying the workings of the csr_read function, which is where the implementations differ.

Also added a script to dns-01 authentication