### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+uacme (1.2.4-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 01:15:12 +0000
+
 uacme (1.2.4-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ uacme (1.2.4-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 01:15:12 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper-compat (= 12),
 Rules-Requires-Root: no
 Standards-Version: 4.5.0
 Homepage: https://github.com/ndilieto/uacme
-Vcs-Git: https://github.com/ndilieto/uacme
+Vcs-Git: https://github.com/ndilieto/uacme.git
 Vcs-Browser: https://github.com/ndilieto/uacme
 
 Package: uacme

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/ndilieto/uacme/issues
+Bug-Submit: https://github.com/ndilieto/uacme/issues/new
+Repository: https://github.com/ndilieto/uacme.git
+Repository-Browse: https://github.com/ndilieto/uacme


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/uacme/31522369-1c0a-4456-898e-4db616698718.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/31522369-1c0a-4456-898e-4db616698718/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/31522369-1c0a-4456-898e-4db616698718/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/31522369-1c0a-4456-898e-4db616698718/diffoscope)).
