### PR TITLE
add option -u, --custom-cert-subdir

### DIFF
--- a/uacme.1.txt
+++ b/uacme.1.txt
@@ -113,6 +113,10 @@ OPTIONS
     Key type, either RSA or EC. Only applies to newly generated keys.
     The bit length can be specified with *-b, --bits*.
 
+*-u, --custom-cert-subdir='SUBDIR'::
+    Replace IDENTIFIER with SUBDIR when determining storage location
+    for certificates and keys (see -c, --confdir)
+
 *-v, --verbose*::
     By default *uacme* only produces output upon errors or when user
     interaction is required. When this option is specified *uacme*


### PR DESCRIPTION
 overwrites use of IDENTIFIER (i.e., common name/first alt name) for the
certificate directory to use within the configuration/account directory

update man page accordingly