### PR TITLE
ualpn.c: fix build with mbedtls 2.x

### DIFF
--- a/ualpn.c
+++ b/ualpn.c
@@ -118,6 +118,10 @@ static const char *_mbedtls_strerror(int code)
     mbedtls_strerror(code, buf, sizeof(buf));
     return buf;
 }
+
+#ifndef MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE
+#define MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE -1
+#endif
 #endif
 
 #if !defined(EAGAIN)


### PR DESCRIPTION
Fix the following build failure with mbedtls 2.x (e.g. 2.28.1) raised since version 1.7.2 and https://github.com/ndilieto/uacme/commit/e580344f5906e10dfb690e92228b1f22b3f5aeba:

```
ualpn.c: In function 'cert_select':
ualpn.c:2283:20: error: 'MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE' undeclared (first use in this function); did you mean 'MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE'?
 2283 |             return MBEDTLS_ERR_SSL_HANDSHAKE_FAILURE;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    MBEDTLS_SSL_ALERT_MSG_HANDSHAKE_FAILURE
```

Fixes:
 - http://autobuild.buildroot.org/results/8fa4f0d2821796be312b366be2f095be07dd7b1e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>