### PR TITLE
Fix ac_fn_c_try_run being defined too late

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -340,28 +340,31 @@ if test "x$OPT_UALPN" != "xno"; then
     AC_RUN_IFELSE([AC_LANG_SOURCE([#include <sys/mman.h>
                      int main() {return mmap(0, 4096, PROT_READ|PROT_WRITE,
                         MAP_ANON|MAP_SHARED, -1, 0) == MAP_FAILED;}])],
-        AC_DEFINE(HAVE_MAP_ANON, 1, [if mmap(MAP_ANON|MAP_SHARED) works])
-        AC_MSG_RESULT([yes]),
-        AC_MSG_RESULT([no])
-        AC_MSG_CHECKING([if mmap("/dev/zero", MAP_SHARED) works])
-        AC_RUN_IFELSE([AC_LANG_SOURCE([#include <sys/mman.h>
-                         #include <sys/stat.h>
-                         #include <fcntl.h>
-                         int main() {return mmap(0, 4096, PROT_READ|PROT_WRITE,
-                            MAP_ANON|MAP_SHARED, open("/dev/zero", O_RDWR), 0) ==
-                            MAP_FAILED;}])],
-            AC_DEFINE(HAVE_MAP_DEVZERO, 1, [if mmap("/dev/zero", MAP_SHARED) works])
-            AC_MSG_RESULT([yes]),
-            AC_MSG_RESULT([no])
-            AC_MSG_ERROR([ualpn requires MAP_ANON or mmap("/dev/zero", MAP_SHARED)])),
-        AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <sys/mman.h>
-                         int main() {return mmap(0, 4096, PROT_READ|PROT_WRITE,
-                            MAP_ANON|MAP_SHARED, -1, 0) == MAP_FAILED;}])],
+        [
             AC_DEFINE(HAVE_MAP_ANON, 1, [if mmap(MAP_ANON|MAP_SHARED) works])
-            AC_MSG_RESULT([yes]),
+            AC_MSG_RESULT([yes])
+        ], [
             AC_MSG_RESULT([no])
-            AC_MSG_NOTICE([falling back to mmap("/dev/zero", MAP_SHARED)])
-            AC_DEFINE(HAVE_MAP_DEVZERO, 1, [if mmap("/dev/zero", MAP_SHARED) works])))
+            AC_MSG_CHECKING([if mmap("/dev/zero", MAP_SHARED) works])
+            AC_RUN_IFELSE([AC_LANG_SOURCE([#include <sys/mman.h>
+                             #include <sys/stat.h>
+                             #include <fcntl.h>
+                             int main() {return mmap(0, 4096, PROT_READ|PROT_WRITE,
+                                MAP_ANON|MAP_SHARED, open("/dev/zero", O_RDWR), 0) ==
+                                MAP_FAILED;}])],
+                AC_DEFINE(HAVE_MAP_DEVZERO, 1, [if mmap("/dev/zero", MAP_SHARED) works])
+                AC_MSG_RESULT([yes]),
+                AC_MSG_RESULT([no])
+                AC_MSG_ERROR([ualpn requires MAP_ANON or mmap("/dev/zero", MAP_SHARED)])),
+            AC_COMPILE_IFELSE([AC_LANG_SOURCE([#include <sys/mman.h>
+                             int main() {return mmap(0, 4096, PROT_READ|PROT_WRITE,
+                                MAP_ANON|MAP_SHARED, -1, 0) == MAP_FAILED;}])],
+                AC_DEFINE(HAVE_MAP_ANON, 1, [if mmap(MAP_ANON|MAP_SHARED) works])
+                AC_MSG_RESULT([yes]),
+                AC_MSG_RESULT([no])
+                AC_MSG_NOTICE([falling back to mmap("/dev/zero", MAP_SHARED)])
+                AC_DEFINE(HAVE_MAP_DEVZERO, 1, [if mmap("/dev/zero", MAP_SHARED) works]))
+        ])
     AC_ARG_ENABLE(splice, AS_HELP_STRING([--disable-splice], [disable splice]))
     if test "x$enable_splice" != "xno"; then
         AC_CHECK_FUNCS([splice])
@@ -406,4 +409,3 @@ AC_SUBST([sysconfdir])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
-


### PR DESCRIPTION
When using GNU autoconf 2.71 to build the configure script it defines the ac_fn_c_try_run function too late, resulting in this error:

```
./configure: line 7440: ac_fn_c_try_run: command not found
```

Quoting the `AC_RUN_IFELSE()` branches fixes this error.

cf. https://lists.gnu.org/archive/html/bug-autoconf/2021-04/msg00001.html