### PR TITLE
initial POC ualpn client library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,9 @@ uacme_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\"" \
 uacme_CFLAGS = $(CURL_CFLAGS) $(WCFLAGS)
 uacme_LDFLAGS = $(CURL_LDFLAGS)
 uacme_LDADD = $(CURL_LDADD)
+if ENABLE_UALPN
+uacme_LDADD += libualpn.la
+endif
 
 if ENABLE_READFILE
 uacme_SOURCES += read-file.c read-file.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,8 @@ ARFLAGS=cr
 bin_PROGRAMS = uacme
 
 if ENABLE_UALPN
-bin_PROGRAMS += ualpn
+bin_PROGRAMS += ualpn ualpnc
+lib_LTLIBRARIES = libualpn.la
 
 ualpn_SOURCES = ualpn.c base64.c base64.h log.c log.h sglib.h
 ualpn_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\""
@@ -37,6 +38,17 @@ libev_a_SOURCES = libev/ev.c
 else
 ualpn_LDADD = $(UALPN_LDADD)
 endif
+
+libualpn_la_SOURCES = libualpn.c
+libualpn_la_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\"" \
+		       -DSYSCONFDIR="\"${sysconfdir}\""
+libualpn_la_CFLAGS = $(WCFLAGS)
+
+ualpnc_SOURCES = ualpnc.c
+ualpnc_CPPFLAGS = -DRUNSTATEDIR="\"${runstatedir}\""
+		 -DSYSCONFDIR="\"${sysconfdir}\""
+ualpnc_CFLAGS = $(WCFLAGS)
+ualpnc_LDADD = libualpn.la
 endif
 
 uacme_SOURCES = uacme.c base64.c base64.h crypto.c crypto.h \

--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,7 @@ if test "x$OPT_UALPN" != "xno"; then
         AC_MSG_ERROR([ualpn is not compatible with LibreSSL])
     fi
     AM_PROG_AR
+    LT_INIT
     AC_CHECK_HEADERS([netinet/tcp.h], [],
                      AC_MSG_ERROR([ualpn requires netinet/tcp.h]))
     AC_CHECK_HEADERS([sys/mman.h], [],

--- a/configure.ac
+++ b/configure.ac
@@ -384,6 +384,9 @@ if test "x$OPT_UALPN" != "xno"; then
 fi
 AC_SUBST(UALPN_LDADD)
 AM_CONDITIONAL(ENABLE_UALPN, test "x$OPT_UALPN" = "xyes")
+if test "x$OPT_UALPN" = "xyes"; then
+    AC_DEFINE(ENABLE_UALPN, 1, [if ualpn is enabled])
+fi
 AM_CONDITIONAL(ENABLE_LIBEV, test "x$with_included_libev" = "xyes")
 
 default_docs="yes"

--- a/libualpn.c
+++ b/libualpn.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2019-2024 Nicola Di Lieto <nicola.dilieto@gmail.com>
+ *
+ * This file is part of uacme.
+ *
+ * uacme is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * uacme is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <err.h>
+
+#include "ualpn.h"
+#include "ualpnc.h"
+
+static void safe_strncpy(char *dst, const char *src, size_t size)
+{
+    strncpy(dst, src, size - 1);
+    dst[size - 1] = '\0';
+}
+
+int ualpn_connect(const char *socket_path, FILE **f)
+{
+    int fd;
+    struct sockaddr_un sock_addr;
+
+    memset(&sock_addr, 0, sizeof(sock_addr));
+    safe_strncpy(sock_addr.sun_path, socket_path, sizeof(sock_addr.sun_path));
+    sock_addr.sun_family = AF_UNIX;
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+        err(1, "failed to create socket");
+        return -1;
+    }
+
+    if (connect(fd, (struct sockaddr *)&sock_addr, sizeof(sock_addr))) {
+        err(1, "failed to connect to unix://%s", socket_path);
+        close(fd);
+        return -1;
+    }
+
+    *f = fdopen(fd, "r+");
+    if (!*f) {
+        err(1, "fdopen failed");
+        close(fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+int ualpn_negotiate_version(FILE *f)
+{
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t r;
+
+    r = getline(&line, &len, f);
+    if (r == -1) {
+        err(1, "failed to read version from server");
+        free(line);
+        return -1;
+    }
+    
+    int server_min, server_max;
+    if (sscanf(line, "VERSION %d %d", &server_min, &server_max) != 2) {
+        errx(1, "invalid version response: %s", line);
+        free(line);
+        return -1;
+    }
+    
+    int client_version = UALPN_PROTOCOL_VERSION_MAX < server_max ? 
+                       UALPN_PROTOCOL_VERSION_MAX : server_max;
+    if (client_version < server_min || client_version < UALPN_PROTOCOL_VERSION_MIN) {
+        errx(1, "incompatible protocol versions (client: %d-%d, server: %d-%d)",
+             UALPN_PROTOCOL_VERSION_MIN, UALPN_PROTOCOL_VERSION_MAX, server_min, server_max);
+        free(line);
+        return -1;
+    }
+    
+    if (fprintf(f, "VERSION %d\n", client_version) < 0) {
+        err(1, "failed to send version to server");
+        free(line);
+        return -1;
+    }
+    
+    r = getline(&line, &len, f);
+    if (r == -1) {
+        err(1, "failed to read version response from server");
+        free(line);
+        return -1;
+    }
+    
+    if (strncmp(line, "OK", 2) != 0) {
+        errx(1, "version negotiation failed: %s", line);
+        free(line);
+        return -1;
+    }
+    
+    free(line);
+    return 0;
+}
+
+int ualpn_auth(FILE *f, const char *ident, const char *auth)
+{
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t r;
+
+    if (fprintf(f, "auth %s %s\n", ident, auth) < 0) {
+        err(1, "failed to send auth command");
+        return -1;
+    }
+    
+    r = getline(&line, &len, f);
+    if (r == -1) {
+        err(1, "failed to read auth response");
+        free(line);
+        return -1;
+    }
+    
+    int result = (strncmp(line, "OK", 2) == 0) ? 0 : -1;
+    if (result != 0) {
+        warnx("auth failed: %s", line);
+    }
+    
+    free(line);
+    return result;
+}
+
+int ualpn_unauth(FILE *f, const char *ident)
+{
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t r;
+
+    if (fprintf(f, "unauth %s\n", ident) < 0) {
+        err(1, "failed to send unauth command");
+        return -1;
+    }
+    
+    r = getline(&line, &len, f);
+    if (r == -1) {
+        err(1, "failed to read unauth response");
+        free(line);
+        return -1;
+    }
+    
+    int result = (strncmp(line, "OK", 2) == 0) ? 0 : -1;
+    if (result != 0) {
+        warnx("unauth failed: %s", line);
+    }
+    
+    free(line);
+    return result;
+}
+
+void ualpn_disconnect(FILE *f)
+{
+    if (f) {
+        fclose(f);
+    }
+}

--- a/ualpn.h
+++ b/ualpn.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019-2024 Nicola Di Lieto <nicola.dilieto@gmail.com>
+ *
+ * This file is part of uacme.
+ *
+ * uacme is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * uacme is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __UALPN_H__
+#define __UALPN_H__
+
+#define DEFAULT_UALPN_SOCKET RUNSTATEDIR "/ualpn.sock"
+#define UALPN_PROTOCOL_VERSION_MAX 1
+#define UALPN_PROTOCOL_VERSION_MIN 1
+
+#endif

--- a/ualpn.sh
+++ b/ualpn.sh
@@ -36,25 +36,5 @@ if [ "$TYPE" != "tls-alpn-01" ]; then
     exit 1
 fi
 
-case "$METHOD" in
-    "begin")
-        UALPN_OUT=$(echo "auth $IDENT $AUTH" | ualpn)
-        if [ "x$UALPN_OUT" = "xOK" ]; then
-            exit 0
-        else
-            exit 1
-        fi
-        ;;
-    "done"|"failed")
-        UALPN_OUT=$(echo "unauth $IDENT" | ualpn)
-        if [ "x$UALPN_OUT" = "xOK" ]; then
-            exit 0
-        else
-            exit 1
-        fi
-        ;;
-    *)
-        echo "$0: invalid method" 1>&2 
-        exit 1
-esac
+exec ualpnc "$METHOD" "$TYPE" "$IDENT" "$TOKEN" "$AUTH"
 

--- a/ualpnc.c
+++ b/ualpnc.c
@@ -1,0 +1,63 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <err.h>
+
+#include "ualpn.h"
+#include "ualpnc.h"
+
+
+static void usage(const char *progname)
+{
+    fprintf(stderr, "Usage: %s method type ident token auth\n", progname);
+    fprintf(stderr, "  method: begin, done, or failed\n");
+    fprintf(stderr, "  type: challenge type (must be tls-alpn-01)\n");
+    fprintf(stderr, "  ident: domain identifier\n");
+    fprintf(stderr, "  token: unused but kept for compatibility\n");
+    fprintf(stderr, "  auth: key authorization (used for begin only)\n");
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 6) {
+        usage(argv[0]);
+        return 85; /* E_BADARGS */
+    }
+
+    const char *method = argv[1];
+    const char *type = argv[2];
+    const char *ident = argv[3];
+    // arg 4 token unused
+    const char *auth = argv[5];
+
+    if (strcmp(type, "tls-alpn-01") != 0) {
+        fprintf(stderr, "skipping %s\n", type);
+        return 1;
+    }
+
+    FILE *f = NULL;
+    int result = 1;
+
+    if (ualpn_connect(DEFAULT_UALPN_SOCKET, &f) != 0) {
+        return 1;
+    }
+
+    if (ualpn_negotiate_version(f) != 0) {
+        ualpn_disconnect(f);
+        return 1;
+    }
+
+    if (strcmp(method, "begin") == 0) {
+        result = ualpn_auth(f, ident, auth) == 0 ? 0 : 1;
+    } else if (strcmp(method, "done") == 0 || strcmp(method, "failed") == 0) {
+        result = ualpn_unauth(f, ident) == 0 ? 0 : 1;
+    } else {
+        fprintf(stderr, "%s: invalid method\n", argv[0]);
+        result = 1;
+    }
+
+    ualpn_disconnect(f);
+    return result;
+}

--- a/ualpnc.h
+++ b/ualpnc.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019-2024 Nicola Di Lieto <nicola.dilieto@gmail.com>
+ *
+ * This file is part of uacme.
+ *
+ * uacme is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * uacme is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __UALPNC_H__
+#define __UALPNC_H__
+
+#include <stdio.h>
+
+int ualpn_connect(const char *socket_path, FILE **f);
+int ualpn_negotiate_version(FILE *f);
+int ualpn_auth(FILE *f, const char *ident, const char *auth);
+int ualpn_unauth(FILE *f, const char *ident);
+void ualpn_disconnect(FILE *f);
+
+#endif


### PR DESCRIPTION
The primary goal of this PR is to create a path to direct "ualpn client" (and maybe uacme client library too) integration into daemons or services.  This has several benefits including:

- tighter integration: key and certificate rollover doesn't require hook scripts; reduced memory footprint
- integration can take the form of client libraries in other languages, Java for example
- allows sharing the scarce resource of port 443 across multiple services and languages, even when only a single public IP is available.
- similarly to Apache2's mod_md, making Let's Encrypt a first class option.  47 day certificates are coming!
- avoid re-implementing a custom ACME client for each application, a library makes the most sense

Consider this an enhancement request, in the form of code.  I'm requesting comments, there's still some rough bits, the default control socket path for example.

Some explanations:
-the version negotiation seems prudent, having a separate client shared library, to take package updates into account.

-versioning also works towards having control clients connecting from other languages.  A custom Jetty webserver project is the inspiration here.  It will incorporate a Java ACME client which connects to ualpn service.

-the shared library isn't quite usable, but would allow direct integration for C and other languages.  I will implement this with uacme as a demonstration.  Instead of using the -h hook script option, a -D <socket> "direct" option would trigger the built-in ualpn client library usage.  Future enhancement would cause "unauth" to happen if the unix control client socket is closed, ie. the requester dies unexpectedly.

Future ideas:
Pass connected socket file descriptors from HTTPS clients to webserver application over the unix socket with SCM_RIGHTS, avoids proxying overhead entirely.  Services without PROXY header support can be supported.